### PR TITLE
Fix CI test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,4 @@
 
   build_script:
     - npm run build
+    - npm run test

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "js"
     ],
     "testMatch": [
-      "**/test/*.js"
+      "<rootDir>/dist/test/*.test.js"
     ]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es5",
+        "lib": [ "es2015" ],
         "noImplicitAny": false,
         "sourceMap": true,
         "outDir": "./dist",


### PR DESCRIPTION
It is running test on `dist/test/*.js` file after build. Maybe we could one step forward to preprocessor TypeScript inside Jest.

I tried [the official way](https://github.com/facebook/jest/tree/master/examples/typescript), but it does not work. Another option is [ts-jest](https://github.com/kulshekhar/ts-jest). Let us revisit it in anothe PR.