### PR TITLE
Update vsts config to use new url format for SSH

### DIFF
--- a/src/host/hostBuilder.ts
+++ b/src/host/hostBuilder.ts
@@ -2,11 +2,11 @@ import Host from "./Host";
 import GitHub from "./github";
 import GitLab from "./gitlab";
 import BitBucket from "./bitbucket";
-import Vsts from './Vsts';
+import Vsts from './vsts';
 import ConfigInfo from "../configInfo";
 
 export default class HostBuilder {
-    static create(info: ConfigInfo): Host{
+    static create(info: ConfigInfo): Host {
         const url = info.remoteUrl;
         if (url.indexOf("gitlab") >= 0) {
             return new GitLab();

--- a/src/host/vsts.ts
+++ b/src/host/vsts.ts
@@ -6,9 +6,9 @@ export default class Vsts implements Host {
     /**
      * The regular expression to match the VSTS Git URL.
      * @example https://my-tenant.visualstudio.com/DefaultCollection/MyCollection/_git/my-repo
-     * @example ssh://my-tenant@my-tenant.visualstudio.com:22/DefaultCollection/MyCollection/_git/my-repo
+     * @example ssh://my-tenant@my-tenant.visualstudio.com:22/DefaultCollection/MyCollection/_ssh/my-repo
      */
-    private static urlRegex: RegExp = /(?:https:\/\/|ssh:\/\/.+@)(.+)\.visualstudio\.com(?:\:\d+)?\/(.+)\/_git\/([^/]+)/i;
+    private static urlRegex: RegExp = /(?:https:\/\/|ssh:\/\/)([\w-]+)@?.*\.visualstudio\.com(?:\:\d+)?\/(.+)\/(?:_git|_ssh)\/([^/]+)/i;
 
     public static match(url: string): boolean {
         return Vsts.urlRegex.test(url);

--- a/test/vsts.test.ts
+++ b/test/vsts.test.ts
@@ -31,13 +31,13 @@ test("Get selection block URL in VSTS", async () => {
 
 test("Get file URL in VSTS with SSH", async () => {
     const configInfo = {
-        remoteUrl: "ssh://ssh@ssh.visualstudio.com:22/Collection/_git/repo",
+        remoteUrl: "ssh://my-tenant@vs-ssh.visualstudio.com:22/Collection/_ssh/repo",
         branchName: "master",
         relativePath: "test/file"
     };
 
     const link = await GitUrls["getUrlAsync"](configInfo);
-    expect(link).toBe("https://ssh.visualstudio.com/Collection/_git/repo?path=%2Ftest%2Ffile&version=GBmaster&_a=contents");
+    expect(link).toBe("https://my-tenant.visualstudio.com/Collection/_git/repo?path=%2Ftest%2Ffile&version=GBmaster&_a=contents");
 });
 
 test("Get selection block URL with column in VSTS", async () => {


### PR DESCRIPTION
Old format repo-url for VSTS will not be supported for long, as seen on message warning displayed when pushing to VSTS with old format:

```» git pull                                                                                                                
remote:
remote: ********************************************************************
remote: *       After November 17th, 2017.                                 *
remote: *       Old SSH remote URLs will be retired and                    *
remote: *       you will need to update your SSH Git remotes.              *
remote: *                                                                  *
remote: *       If you haven't already done this:                          *
remote: *       - Visit your VSTS repository on the web.                   *
remote: *       - Press the "Clone" button on the top right corner.        *
remote: *       - Press "SSH" and copy the new SSH remote URL.             *
remote: *       - In your Git client, run the following:                   *
remote: *             git remote set-url {remote_name} {new_ssh_url}       *
remote: *                                                                  *
remote: *       For more information, refer to                             *
remote: *             https://go.microsoft.com/fwlink/?linkid=855768       *
remote: ********************************************************************
remote:```

This PR accept the new SSH format, and tests has been updated