### PR TITLE
Generate detached HEAD links

### DIFF
--- a/src/configInfo.ts
+++ b/src/configInfo.ts
@@ -1,14 +1,15 @@
+import Ref from "./ref";
 import Section from "./section";
 
 export default class ConfigInfo {
     remoteUrl: string;
-    commit: string;
+    ref: Ref;
     relativePath?: string;
     section?: Section;
 
-    constructor(remoteUrl: string, commit: string, relativePath?: string, section?: Section) {
+    constructor(remoteUrl: string, ref: Ref, relativePath?: string, section?: Section) {
         this.remoteUrl = remoteUrl;
-        this.commit = commit;
+        this.ref = ref;
         this.relativePath = relativePath;
         this.section = section;
     }

--- a/src/configInfo.ts
+++ b/src/configInfo.ts
@@ -2,13 +2,13 @@ import Section from "./section";
 
 export default class ConfigInfo {
     remoteUrl: string;
-    branchName: string;
+    commit: string;
     relativePath?: string;
     section?: Section;
 
-    constructor(remoteUrl: string, branchName: string, relativePath?: string, section?: Section) {
+    constructor(remoteUrl: string, commit: string, relativePath?: string, section?: Section) {
         this.remoteUrl = remoteUrl;
-        this.branchName = branchName;
+        this.commit = commit;
         this.relativePath = relativePath;
         this.section = section;
     }

--- a/src/gitInfo.ts
+++ b/src/gitInfo.ts
@@ -1,18 +1,19 @@
+import Ref from "./ref";
 import Section from "./section";
 
 export default class GitInfo {
     repoName: string;
-    commit: string;
+    ref: Ref;
     userName: string;
     hostName?: string;
     relativefilePath?: string;
     section?: Section;
     metadata?: object;
 
-    constructor(repoName: string, commit: string, userName: string, hostName?: string, relativeFilePath?: string, section?: Section, metadata?: object) {
+    constructor(repoName: string, ref: Ref, userName: string, hostName?: string, relativeFilePath?: string, section?: Section, metadata?: object) {
         this.hostName = hostName;
         this.repoName = repoName;
-        this.commit = commit;
+        this.ref = ref;
         this.userName = userName;
         this.relativefilePath = relativeFilePath;
         this.section = section;

--- a/src/gitInfo.ts
+++ b/src/gitInfo.ts
@@ -2,17 +2,17 @@ import Section from "./section";
 
 export default class GitInfo {
     repoName: string;
-    branchName: string;
+    commit: string;
     userName: string;
     hostName?: string;
     relativefilePath?: string;
     section?: Section;
     metadata?: object;
 
-    constructor(repoName: string, branchName: string, userName: string, hostName?: string, relativeFilePath?: string, section?: Section, metadata?: object) {
+    constructor(repoName: string, commit: string, userName: string, hostName?: string, relativeFilePath?: string, section?: Section, metadata?: object) {
         this.hostName = hostName;
         this.repoName = repoName;
-        this.branchName = branchName;
+        this.commit = commit;
         this.userName = userName;
         this.relativefilePath = relativeFilePath;
         this.section = section;

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -19,7 +19,7 @@ export default class Helper {
         const headContent = await fs.readFile(headPath, "utf8");
 
         const remoteMap = this.parseRemoteUrl(configContent);
-        const branch = this.parseBranchName(headContent);
+        const branch = this.parsecommit(headContent);
 
         if (!remoteMap) {
             throw new Error(`Can't get remote name/url from ${configPath}.`);
@@ -80,7 +80,7 @@ export default class Helper {
         return null;
     }
 
-    private static parseBranchName(content: string): string | null {
+    private static parsecommit(content: string): string | null {
         const regex = /ref:\s+refs\/heads\/(\S+)/;
         const matches = regex.exec(content);
         if (!matches) {

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -2,6 +2,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 
 import ConfigInfo from "./configInfo";
+import Ref from "./ref";
 
 export default class Helper {
     public static async parseConfigAsync(repoRoot: string): Promise<Map<string, ConfigInfo>> {
@@ -19,19 +20,15 @@ export default class Helper {
         const headContent = await fs.readFile(headPath, "utf8");
 
         const remoteMap = this.parseRemoteUrl(configContent);
-        const branch = this.parsecommit(headContent);
+        const ref = this.parseRef(headContent);
 
         if (!remoteMap) {
             throw new Error(`Can't get remote name/url from ${configPath}.`);
         }
 
-        if (!branch) {
-            throw new Error(`Can't get branch name from ${headPath}.`);
-        }
-
         var configMap = new Map<string, ConfigInfo>();
         for (let [key, value] of remoteMap) {
-            configMap.set(key, new ConfigInfo(value, branch))
+            configMap.set(key, new ConfigInfo(value, ref))
         }
 
         return configMap;
@@ -80,13 +77,13 @@ export default class Helper {
         return null;
     }
 
-    private static parsecommit(content: string): string | null {
-        const regex = /ref:\s+refs\/heads\/(\S+)/;
-        const matches = regex.exec(content);
-        if (!matches) {
-            return null;
+    private static parseRef(content: string): Ref {
+        const branchRegex = /ref:\s+refs\/heads\/(\S+)/;
+        const branchMatches = branchRegex.exec(content);
+        if (branchMatches) {
+            return { type: "branch", value: branchMatches[1] }
         }
 
-        return matches[1];
+        return { type: "commit", value: content };
     }
 }

--- a/src/host/basicHost.ts
+++ b/src/host/basicHost.ts
@@ -48,6 +48,6 @@ export default abstract class BasicHost implements Host {
             prefix = "http://";
         }
 
-        return `${prefix}${info.hostName}/${info.userName}/${info.repoName}/${this.separateFolder}/${info.commit}/${info.relativefilePath}`;
+        return `${prefix}${info.hostName}/${info.userName}/${info.repoName}/${this.separateFolder}/${info.ref.value}/${info.relativefilePath}`;
     }
 }

--- a/src/host/basicHost.ts
+++ b/src/host/basicHost.ts
@@ -32,7 +32,7 @@ export default abstract class BasicHost implements Host {
         return {
             hostName: hostName,
             repoName: repoName,
-            commit: info.commit,
+            ref: info.ref,
             userName: matches[3],
             metadata: { "isHttp": isHttp },
         }

--- a/src/host/basicHost.ts
+++ b/src/host/basicHost.ts
@@ -32,7 +32,7 @@ export default abstract class BasicHost implements Host {
         return {
             hostName: hostName,
             repoName: repoName,
-            branchName: info.branchName,
+            commit: info.commit,
             userName: matches[3],
             metadata: { "isHttp": isHttp },
         }
@@ -48,6 +48,6 @@ export default abstract class BasicHost implements Host {
             prefix = "http://";
         }
 
-        return `${prefix}${info.hostName}/${info.userName}/${info.repoName}/${this.separateFolder}/${info.branchName}/${info.relativefilePath}`;
+        return `${prefix}${info.hostName}/${info.userName}/${info.repoName}/${this.separateFolder}/${info.commit}/${info.relativefilePath}`;
     }
 }

--- a/src/host/devops.ts
+++ b/src/host/devops.ts
@@ -26,7 +26,18 @@ export default class DevOps implements Host {
     public assemble(info: GitInfo): string {
         const baseUrl = info.repoName.replace(DevOps.urlRegex, "https://dev.azure.com/$1/_git/$2");
         const path: string = encodeURIComponent(`/${info.relativefilePath}`);
-        let url = `${baseUrl}?path=${path}&version=GB${info.commit}&_a=contents`;
+
+        let version: string;
+        switch (info.ref.type) {
+            case "branch":
+                version = `GB${info.ref.value}`
+                break;
+            case "commit":
+                version = `GC${info.ref.value}`
+                break;
+        }
+
+        let url = `${baseUrl}?path=${path}&version=${version}&_a=contents`;
 
         if (info.section && info.section.startLine && info.section.endLine) {
             url += `&lineStyle=plain&line=${info.section.startLine}&lineEnd=${info.section.endLine}`;

--- a/src/host/devops.ts
+++ b/src/host/devops.ts
@@ -18,7 +18,7 @@ export default class DevOps implements Host {
     public parse(info: ConfigInfo): GitInfo {
         return {
             repoName: info.remoteUrl,
-            branchName: info.branchName,
+            commit: info.commit,
             userName: ''
         }
     }
@@ -26,7 +26,7 @@ export default class DevOps implements Host {
     public assemble(info: GitInfo): string {
         const baseUrl = info.repoName.replace(DevOps.urlRegex, "https://dev.azure.com/$1/_git/$2");
         const path: string = encodeURIComponent(`/${info.relativefilePath}`);
-        let url = `${baseUrl}?path=${path}&version=GB${info.branchName}&_a=contents`;
+        let url = `${baseUrl}?path=${path}&version=GB${info.commit}&_a=contents`;
 
         if (info.section && info.section.startLine && info.section.endLine) {
             url += `&lineStyle=plain&line=${info.section.startLine}&lineEnd=${info.section.endLine}`;

--- a/src/host/devops.ts
+++ b/src/host/devops.ts
@@ -18,7 +18,7 @@ export default class DevOps implements Host {
     public parse(info: ConfigInfo): GitInfo {
         return {
             repoName: info.remoteUrl,
-            commit: info.commit,
+            ref: info.ref,
             userName: ''
         }
     }

--- a/src/host/vsts.ts
+++ b/src/host/vsts.ts
@@ -25,7 +25,18 @@ export default class Vsts implements Host {
     public assemble(info: GitInfo): string {
         const baseUrl = info.repoName.replace(Vsts.urlRegex, "https://$1.visualstudio.com/$2/_git/$3");
         const path: string = encodeURIComponent(`/${info.relativefilePath}`);
-        let url = `${baseUrl}?path=${path}&version=GB${info.commit}&_a=contents`;
+
+        let version: string;
+        switch (info.ref.type) {
+            case "branch":
+                version = `GB${info.ref.value}`
+                break;
+            case "commit":
+                version = `GC${info.ref.value}`
+                break;
+        }
+
+        let url = `${baseUrl}?path=${path}&version=${version}&_a=contents`;
 
         if (info.section && info.section.startLine && info.section.endLine) {
             url += `&lineStyle=plain&line=${info.section.startLine}&lineEnd=${info.section.endLine}`;

--- a/src/host/vsts.ts
+++ b/src/host/vsts.ts
@@ -17,7 +17,7 @@ export default class Vsts implements Host {
     public parse(info: ConfigInfo): GitInfo {
         return {
             repoName: info.remoteUrl,
-            commit: info.commit,
+            ref: info.ref,
             userName: ''
         }
     }

--- a/src/host/vsts.ts
+++ b/src/host/vsts.ts
@@ -17,7 +17,7 @@ export default class Vsts implements Host {
     public parse(info: ConfigInfo): GitInfo {
         return {
             repoName: info.remoteUrl,
-            branchName: info.branchName,
+            commit: info.commit,
             userName: ''
         }
     }
@@ -25,7 +25,7 @@ export default class Vsts implements Host {
     public assemble(info: GitInfo): string {
         const baseUrl = info.repoName.replace(Vsts.urlRegex, "https://$1.visualstudio.com/$2/_git/$3");
         const path: string = encodeURIComponent(`/${info.relativefilePath}`);
-        let url = `${baseUrl}?path=${path}&version=GB${info.branchName}&_a=contents`;
+        let url = `${baseUrl}?path=${path}&version=GB${info.commit}&_a=contents`;
 
         if (info.section && info.section.startLine && info.section.endLine) {
             url += `&lineStyle=plain&line=${info.section.startLine}&lineEnd=${info.section.endLine}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,7 @@ export default class GitUrls {
             gitInfo.relativefilePath = parts.join('/');
         }
 
-        if (configInfo.commit) {
-            gitInfo.commit = encodeURIComponent(configInfo.commit);
-        }
+        gitInfo.ref = { ...configInfo.ref, value: encodeURIComponent(configInfo.ref.value) };
 
         return host.assemble(gitInfo);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export default class GitUrls {
             gitInfo.relativefilePath = parts.join('/');
         }
 
-        if (configInfo.branchName) {
-            gitInfo.branchName = encodeURIComponent(configInfo.branchName);
+        if (configInfo.commit) {
+            gitInfo.commit = encodeURIComponent(configInfo.commit);
         }
 
         return host.assemble(gitInfo);

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,0 +1,4 @@
+export default interface Ref {
+  type: 'branch' | 'commit';
+  value: string;
+}

--- a/test/bitbucket.test.ts
+++ b/test/bitbucket.test.ts
@@ -5,7 +5,7 @@ import GitUrls from "../src/index";
 test("Get HTTPS url in BitBucket", async () => {
     const configInfo = {
         remoteUrl: "https://bitbucket.org/qinezh/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -16,7 +16,7 @@ test("Get HTTPS url in BitBucket", async () => {
 test("Get SSH URL in BitBucket", async () => {
     const configInfo = {
         remoteUrl: "git@bitbucket.org:qinezh/git-urls.git",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 2,
             endLine: 3,

--- a/test/bitbucket.test.ts
+++ b/test/bitbucket.test.ts
@@ -29,3 +29,14 @@ test("Get SSH URL in BitBucket", async () => {
 
     expect(link).toBe("https://bitbucket.org/qinezh/git-urls/src/master/test/a.md#a.md-2:3");
 });
+
+test("Get URL with commit SHA in BitBucket", async () => {
+    const configInfo = {
+        remoteUrl: "https://bitbucket.org/qinezh/git-urls.git",
+        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        relativePath: "test/a.md"
+    }
+    const link = await GitUrls["getUrlAsync"](configInfo);
+
+    expect(link).toBe("https://bitbucket.org/qinezh/git-urls/src/59f76230dd5829a10aab717265b66c6b5849365e/test/a.md");
+});

--- a/test/bitbucket.test.ts
+++ b/test/bitbucket.test.ts
@@ -1,11 +1,12 @@
 import * as path from "path";
+import ConfigInfo from "../src/configInfo";
 
 import GitUrls from "../src/index";
 
 test("Get HTTPS url in BitBucket", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://bitbucket.org/qinezh/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -14,9 +15,9 @@ test("Get HTTPS url in BitBucket", async () => {
 });
 
 test("Get SSH URL in BitBucket", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "git@bitbucket.org:qinezh/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 2,
             endLine: 3,
@@ -31,9 +32,9 @@ test("Get SSH URL in BitBucket", async () => {
 });
 
 test("Get URL with commit SHA in BitBucket", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://bitbucket.org/qinezh/git-urls.git",
-        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        ref: { type: "commit", value: "59f76230dd5829a10aab717265b66c6b5849365e"},
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);

--- a/test/bitbucket.test.ts
+++ b/test/bitbucket.test.ts
@@ -1,6 +1,4 @@
-import * as path from "path";
 import ConfigInfo from "../src/configInfo";
-
 import GitUrls from "../src/index";
 
 test("Get HTTPS url in BitBucket", async () => {

--- a/test/devops.test.ts
+++ b/test/devops.test.ts
@@ -4,9 +4,9 @@ import ConfigInfo from "../src/configInfo";
 import GitUrls from "../src/index";
 
 test("Get file URL in DevOps", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/file"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -15,9 +15,9 @@ test("Get file URL in DevOps", async () => {
 });
 
 test("Get selection block URL in DevOps", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 12,
             endLine: 23
@@ -30,9 +30,9 @@ test("Get selection block URL in DevOps", async () => {
 });
 
 test("Get file URL in DevOps with SSH", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "my-tenant@ssh.dev.azure.com:22/my-org/my-project/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/file"
     };
 
@@ -41,9 +41,9 @@ test("Get file URL in DevOps with SSH", async () => {
 });
 
 test("Get selection block URL with column in DevOps", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 12,
             endLine: 23,
@@ -58,9 +58,9 @@ test("Get selection block URL with column in DevOps", async () => {
 });
 
 test("Get URL with commit SHA in DevOps", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        ref: { type: "commit", value: "59f76230dd5829a10aab717265b66c6b5849365e"},
         relativePath: "test/file"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);

--- a/test/devops.test.ts
+++ b/test/devops.test.ts
@@ -6,7 +6,7 @@ import GitUrls from "../src/index";
 test("Get file URL in DevOps", async () => {
     const configInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/file"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -17,7 +17,7 @@ test("Get file URL in DevOps", async () => {
 test("Get selection block URL in DevOps", async () => {
     const configInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 12,
             endLine: 23
@@ -32,7 +32,7 @@ test("Get selection block URL in DevOps", async () => {
 test("Get file URL in DevOps with SSH", async () => {
     const configInfo = {
         remoteUrl: "my-tenant@ssh.dev.azure.com:22/my-org/my-project/repo",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/file"
     };
 
@@ -43,7 +43,7 @@ test("Get file URL in DevOps with SSH", async () => {
 test("Get selection block URL with column in DevOps", async () => {
     const configInfo = {
         remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 12,
             endLine: 23,

--- a/test/devops.test.ts
+++ b/test/devops.test.ts
@@ -56,3 +56,14 @@ test("Get selection block URL with column in DevOps", async () => {
 
     expect(link).toBe("https://dev.azure.com/my-org/my-project/_git/repo?path=%2Ftest%2Ffile&version=GBmaster&_a=contents&lineStyle=plain&line=12&lineEnd=23&lineStartColumn=8&lineEndColumn=9");
 });
+
+test("Get URL with commit SHA in DevOps", async () => {
+    const configInfo = {
+        remoteUrl: "https://dev.azure.com/my-org/my-project/_git/repo",
+        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        relativePath: "test/file"
+    }
+    const link = await GitUrls["getUrlAsync"](configInfo);
+
+    expect(link).toBe("https://dev.azure.com/my-org/my-project/_git/repo?path=%2Ftest%2Ffile&version=GC59f76230dd5829a10aab717265b66c6b5849365e&_a=contents");
+});

--- a/test/devops.test.ts
+++ b/test/devops.test.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-
 import ConfigInfo from "../src/configInfo";
 import GitUrls from "../src/index";
 

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -88,3 +88,14 @@ test("Get URL with specical branch in GitHub", async () => {
     const link = await GitUrls["getUrlAsync"](configInfo);
     expect(link).toBe("https://github.com/build/git-urls/blob/%23test/a.md");
 });
+
+test("Get URL with commit SHA in GitHub", async () => {
+    const configInfo = {
+        remoteUrl: "https://github.com/build/git-urls.git",
+        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        relativePath: "test/a.md"
+    }
+    const link = await GitUrls["getUrlAsync"](configInfo);
+
+    expect(link).toBe("https://github.com/build/git-urls/blob/59f76230dd5829a10aab717265b66c6b5849365e/test/a.md");
+});

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -10,7 +10,7 @@ import GitUrls from "../src/index";
 test("Get HTTPS URL in GitHub", async () => {
     const configInfo = {
         remoteUrl: "https://github.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -21,7 +21,7 @@ test("Get HTTPS URL in GitHub", async () => {
 test("Get SSH URL in GitHub", async () => {
     const configInfo = {
         remoteUrl: "git@github.com:qinezh/git-urls",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -32,7 +32,7 @@ test("Get SSH URL in GitHub", async () => {
 test("Get HTTP URL in GitHub", async () => {
     const configInfo = {
         remoteUrl: "http://github.com/qinezh/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -43,7 +43,7 @@ test("Get HTTP URL in GitHub", async () => {
 test("Get HTTPS URL with username in GitHub", async () => {
     const configInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -54,7 +54,7 @@ test("Get HTTPS URL with username in GitHub", async () => {
 test("Get URL with space in file path in GitHub", async () => {
     const configInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test space in path/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -65,7 +65,7 @@ test("Get URL with space in file path in GitHub", async () => {
 test("Get URL with section in GitHub", async () => {
     const configInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 2,
             endLine: 3,
@@ -82,7 +82,7 @@ test("Get URL with section in GitHub", async () => {
 test("Get URL with specical branch in GitHub", async () => {
     const configInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        branchName: "#test",
+        commit: "#test",
         relativePath: "a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,5 +1,4 @@
 import ConfigInfo from "../src/configInfo";
-
 import GitUrls from "../src/index";
 
 // test("Get current project's git online link", async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import ConfigInfo from "../src/configInfo";
 
 import GitUrls from "../src/index";
 
@@ -8,9 +8,9 @@ import GitUrls from "../src/index";
 // });
 
 test("Get HTTPS URL in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://github.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -19,9 +19,9 @@ test("Get HTTPS URL in GitHub", async () => {
 });
 
 test("Get SSH URL in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "git@github.com:qinezh/git-urls",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -30,9 +30,9 @@ test("Get SSH URL in GitHub", async () => {
 });
 
 test("Get HTTP URL in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "http://github.com/qinezh/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -41,9 +41,9 @@ test("Get HTTP URL in GitHub", async () => {
 });
 
 test("Get HTTPS URL with username in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -52,9 +52,9 @@ test("Get HTTPS URL with username in GitHub", async () => {
 });
 
 test("Get URL with space in file path in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test space in path/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -63,9 +63,9 @@ test("Get URL with space in file path in GitHub", async () => {
 });
 
 test("Get URL with section in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 2,
             endLine: 3,
@@ -80,9 +80,9 @@ test("Get URL with section in GitHub", async () => {
 });
 
 test("Get URL with specical branch in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://qinezh@github.com/build/git-urls.git",
-        commit: "#test",
+        ref: { type: "branch", value: "#test" },
         relativePath: "a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -90,9 +90,9 @@ test("Get URL with specical branch in GitHub", async () => {
 });
 
 test("Get URL with commit SHA in GitHub", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://github.com/build/git-urls.git",
-        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        ref: { type: "commit", value: "59f76230dd5829a10aab717265b66c6b5849365e" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);

--- a/test/gitlab.test.ts
+++ b/test/gitlab.test.ts
@@ -5,7 +5,7 @@ import GitUrls from "../src/index";
 test("Get HTTPS url in GitLab", async () => {
     const configInfo = {
         remoteUrl: "https://gitlab.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -16,7 +16,7 @@ test("Get HTTPS url in GitLab", async () => {
 test("Get SSH URL in GitLab", async () => {
     const configInfo = {
         remoteUrl: "git@gitlab.com:qinezh/git-urls",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -27,7 +27,7 @@ test("Get SSH URL in GitLab", async () => {
 test("Get HTTPS url in GitLab with company name", async () => {
     const configInfo = {
         remoteUrl: "https://gitlab.xyz.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -38,7 +38,7 @@ test("Get HTTPS url in GitLab with company name", async () => {
 test("Get SSH URL in GitLab with company name", async () => {
     const configInfo = {
         remoteUrl: "git@gitlab.xyz.com:qinezh/git-urls",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -49,7 +49,7 @@ test("Get SSH URL in GitLab with company name", async () => {
 test("Get URL with section in GitLab", async () => {
     const configInfo = {
         remoteUrl: "https://qinezh@gitlab.com/build/git-urls.git",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 2,
             endLine: 3,

--- a/test/gitlab.test.ts
+++ b/test/gitlab.test.ts
@@ -62,3 +62,14 @@ test("Get URL with section in GitLab", async () => {
 
     expect(link).toBe("https://gitlab.com/build/git-urls/blob/master/a.md#L2-3");
 });
+
+test("Get URL with commit SHA in GitLab", async () => {
+    const configInfo = {
+        remoteUrl: "https://gitlab.com/build/git-urls.git",
+        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        relativePath: "test/a.md"
+    }
+    const link = await GitUrls["getUrlAsync"](configInfo);
+
+    expect(link).toBe("https://gitlab.com/build/git-urls/blob/59f76230dd5829a10aab717265b66c6b5849365e/test/a.md");
+});

--- a/test/gitlab.test.ts
+++ b/test/gitlab.test.ts
@@ -1,6 +1,4 @@
-import * as path from "path";
 import ConfigInfo from "../src/configInfo";
-
 import GitUrls from "../src/index";
 
 test("Get HTTPS url in GitLab", async () => {

--- a/test/gitlab.test.ts
+++ b/test/gitlab.test.ts
@@ -1,11 +1,12 @@
 import * as path from "path";
+import ConfigInfo from "../src/configInfo";
 
 import GitUrls from "../src/index";
 
 test("Get HTTPS url in GitLab", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://gitlab.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -14,9 +15,9 @@ test("Get HTTPS url in GitLab", async () => {
 });
 
 test("Get SSH URL in GitLab", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "git@gitlab.com:qinezh/git-urls",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -25,9 +26,9 @@ test("Get SSH URL in GitLab", async () => {
 });
 
 test("Get HTTPS url in GitLab with company name", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://gitlab.xyz.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -36,9 +37,9 @@ test("Get HTTPS url in GitLab with company name", async () => {
 });
 
 test("Get SSH URL in GitLab with company name", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "git@gitlab.xyz.com:qinezh/git-urls",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -47,9 +48,9 @@ test("Get SSH URL in GitLab with company name", async () => {
 });
 
 test("Get URL with section in GitLab", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://qinezh@gitlab.com/build/git-urls.git",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 2,
             endLine: 3,
@@ -64,9 +65,9 @@ test("Get URL with section in GitLab", async () => {
 });
 
 test("Get URL with commit SHA in GitLab", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://gitlab.com/build/git-urls.git",
-        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        ref: { type: "commit", value: "59f76230dd5829a10aab717265b66c6b5849365e" },
         relativePath: "test/a.md"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);

--- a/test/vsts.test.ts
+++ b/test/vsts.test.ts
@@ -56,3 +56,14 @@ test("Get selection block URL with column in VSTS", async () => {
 
     expect(link).toBe("https://vsts.visualstudio.com/Collection/_git/repo?path=%2Ftest%2Ffile&version=GBmaster&_a=contents&lineStyle=plain&line=12&lineEnd=23&lineStartColumn=8&lineEndColumn=9");
 });
+
+test("Get URL with commit SHA in VSTS", async () => {
+    const configInfo = {
+        remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
+        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        relativePath: "test/file"
+    }
+    const link = await GitUrls["getUrlAsync"](configInfo);
+
+    expect(link).toBe("https://vsts.visualstudio.com/Collection/_git/repo?path=%2Ftest%2Ffile&version=GC59f76230dd5829a10aab717265b66c6b5849365e&_a=contents");
+});

--- a/test/vsts.test.ts
+++ b/test/vsts.test.ts
@@ -6,7 +6,7 @@ import GitUrls from "../src/index";
 test("Get file URL in VSTS", async () => {
     const configInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/file"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -17,7 +17,7 @@ test("Get file URL in VSTS", async () => {
 test("Get selection block URL in VSTS", async () => {
     const configInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 12,
             endLine: 23
@@ -32,7 +32,7 @@ test("Get selection block URL in VSTS", async () => {
 test("Get file URL in VSTS with SSH", async () => {
     const configInfo = {
         remoteUrl: "ssh://my-tenant@vs-ssh.visualstudio.com:22/Collection/_ssh/repo",
-        branchName: "master",
+        commit: "master",
         relativePath: "test/file"
     };
 
@@ -43,7 +43,7 @@ test("Get file URL in VSTS with SSH", async () => {
 test("Get selection block URL with column in VSTS", async () => {
     const configInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        branchName: "master",
+        commit: "master",
         section: {
             startLine: 12,
             endLine: 23,

--- a/test/vsts.test.ts
+++ b/test/vsts.test.ts
@@ -4,9 +4,9 @@ import ConfigInfo from "../src/configInfo";
 import GitUrls from "../src/index";
 
 test("Get file URL in VSTS", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/file"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);
@@ -15,9 +15,9 @@ test("Get file URL in VSTS", async () => {
 });
 
 test("Get selection block URL in VSTS", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 12,
             endLine: 23
@@ -30,9 +30,9 @@ test("Get selection block URL in VSTS", async () => {
 });
 
 test("Get file URL in VSTS with SSH", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "ssh://my-tenant@vs-ssh.visualstudio.com:22/Collection/_ssh/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         relativePath: "test/file"
     };
 
@@ -41,9 +41,9 @@ test("Get file URL in VSTS with SSH", async () => {
 });
 
 test("Get selection block URL with column in VSTS", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        commit: "master",
+        ref: { type: "branch", value: "master" },
         section: {
             startLine: 12,
             endLine: 23,
@@ -58,9 +58,9 @@ test("Get selection block URL with column in VSTS", async () => {
 });
 
 test("Get URL with commit SHA in VSTS", async () => {
-    const configInfo = {
+    const configInfo: ConfigInfo = {
         remoteUrl: "https://vsts.visualstudio.com/Collection/_git/repo",
-        commit: "59f76230dd5829a10aab717265b66c6b5849365e",
+        ref: { type: "commit", value: "59f76230dd5829a10aab717265b66c6b5849365e"},
         relativePath: "test/file"
     }
     const link = await GitUrls["getUrlAsync"](configInfo);

--- a/test/vsts.test.ts
+++ b/test/vsts.test.ts
@@ -1,5 +1,3 @@
-import * as path from "path";
-
 import ConfigInfo from "../src/configInfo";
 import GitUrls from "../src/index";
 


### PR DESCRIPTION
This PR adds support for generating links when in a [detached HEAD state][1].

I accomplished this by introducing a `Ref` type that can represent either a branch or commit reference. The parsing of the `.git/HEAD` file differentiates between the two cases based on whether the file starts with the `ref: ` prefix. This is vaguely documented [in the Git book][2] and I've confirmed the behavior manually.

For the "basic" hosts, the commit SHA just goes in place of the branch name. Based on some quick research, Azure DevOps and VSTS seem to use a `GC` prefix for commits in the `version` query param (as opposed to `GB` for branches).

[1]: https://git-scm.com/docs/git-checkout#_detached_head
[2]: https://git-scm.com/book/en/v2/Git-Internals-Git-References#ref_the_ref