### PR TITLE
Ignore Heroku URLs when parsing git remotes as they are not-linkable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ export default class GitUrls {
                 configInfo.section = section;
             }
 
+            if (/(https?:\/\/)heroku.com\//.exec(configInfo.remoteUrl)) {
+                continue
+            }
+
             const url = await this.getUrlAsync(configInfo);
             urlsMap.set(key, url);
         }


### PR DESCRIPTION
Heroku URLs aren't directly linkable in the normal way, even though they present as a git remote. So skip any matching Heroku's URL. https://github.com/qinezh/vscode-gitlink/issues/41